### PR TITLE
Add a database configuration for travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: ruby
 rvm:
   1.9.3
-before_script: RAILS_ENV=test rake db:migrate --trace
+before_script:
+  - cp config/travis.database.yml config/database.yml
+  - psql -c 'create database presentations_test;' -U postgres
+  - RAILS_ENV=test rake db:migrate --trace

--- a/config/travis.database.yml
+++ b/config/travis.database.yml
@@ -1,0 +1,13 @@
+# Travis CI requires the username `postgres` when using postgresql as
+# the database service. This however clashes with the common postgresql
+# installation on Macs (i.e. the postgres username is the system username).
+test: &test
+  adapter: postgresql
+  username: postgres
+  encoding: unicode
+  database: presentations_test
+  pool: 5
+  min_messages: WARNING
+
+cucumber:
+  <<: *test


### PR DESCRIPTION
Travis CI requires the username `postgres` when using postgresql as the database service. This however clashes with the common postgresql installation on Macs (i.e. the postgres username is the system username).

Besides that create the database before running the migrations.

See http://about.travis-ci.org/docs/user/database-setup/#PostgreSQL 
